### PR TITLE
Improve favicon inclusion

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -14,7 +14,7 @@
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
     <meta name="description" content="pgp.help is a modern client-side tool for encrypting and decrypting PGP / OpenPGP / GnuPG messages."/>
     <meta name="author" content=""/>
-    <link rel="icon" href="favicon.png"/>
+    <link rel="icon" href="./favicon.png" type="image/png" sizes="32x32"/>
     <title>pgp.help - Modern javascript client-side PGP encryption and decryption tool</title>
 
     <!-- build:css css/main.css -->


### PR DESCRIPTION
also works in subdirs now

However it would be far better to also include apples touch icons, old .ico files and more. This can be easily done with https://realfavicongenerator.net/, but I need a high-quality (>= 260x260px) PNG file for this.